### PR TITLE
Appcast case for DevMate apps

### DIFF
--- a/scripts/recipe_robot_lib/inspect.py
+++ b/scripts/recipe_robot_lib/inspect.py
@@ -267,6 +267,8 @@ def inspect_app(input_path, args, facts):
             sparkle_feed = info_plist["SUFeedURL"]
         elif "SUOriginalFeedURL" in info_plist:
             sparkle_feed = info_plist["SUOriginalFeedURL"]
+        elif os.path.exists("%s/Contents/Frameworks/DevMateKit.framework" % input_path):
+        	sparkle_feed = ("https://updates.devmate.com/%s.xml") % bundle_id
         if sparkle_feed != "" and sparkle_feed != "NULL":
             facts = inspect_sparkle_feed_url(sparkle_feed, args, facts)
         else:


### PR DESCRIPTION
DevMate enabled apps hide their appcast URLs by generating them out of the DevMate framework binary. This will allow Recipe Robot to generate the URLs the same way when the DevMateKit framework is detected in the app.