### PR TITLE
Fix 160

### DIFF
--- a/scripts/recipe_robot_lib/facts.py
+++ b/scripts/recipe_robot_lib/facts.py
@@ -47,8 +47,6 @@ class NotificationMixin(object):
 
     def send_notification(self, message):
         """Send an NSNotification to our stored center."""
-        if isinstance(message, str):
-            message = message.encode("utf-8")
         userInfo = {"message": message}  # pylint: disable=invalid-name
         self.notification_center.postNotificationName_object_userInfo_options_(
             "com.elliotjordan.recipe-robot.dnc.%s" % self.message_type,


### PR DESCRIPTION
I took a look.

Sorry for the delay friend ;)

So, try firing up python3 and doing
```
from Foundation import NSString
NSString("All good 🌮")
NSString("Uh oh 💩".encode())
NSString(b"Definitely not")
```

So I removed the part where the send notification func is encoding messages prior to being stuffed into a notification and voila! Recipe Robot is happy again.