### PR TITLE
remove the obsolete TODO comment

### DIFF
--- a/scripts/recipe_robot_lib/recipe_generator.py
+++ b/scripts/recipe_robot_lib/recipe_generator.py
@@ -1699,7 +1699,6 @@ def generate_bigfix_recipe(facts, prefs, recipe):
                 "bes_title": "Install/Upgrade: "
                 + facts["developer"]
                 + " %NAME% %version% - macOS",
-                # TODO: Might be a problem with <![CDATA[ being escaped incorrectly in resulting recipe
                 "bes_description": "<p>This task will install/upgrade: %NAME% %version%</p>",
                 "bes_category": "Software Installers",
                 "bes_relevance": [


### PR DESCRIPTION
##### SUMMARY
Remove the obsolete TODO comment. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
scripts/recipe_robot_lib/recipe_generator.py (line:1702)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not removed accordingly at the moment. Please check the following commit: 
https://github.com/homebysix/recipe-robot/commit/a47f2e6fbd62d55e1ab96676fba0b96becca2384